### PR TITLE
Add null check for sendEventAsync method result

### DIFF
--- a/twin-reflector-proxy/twin-reflector-proxy-core/src/main/java/com/microsoft/twins/reflector/telemetry/TelemetryForwarder.java
+++ b/twin-reflector-proxy/twin-reflector-proxy-core/src/main/java/com/microsoft/twins/reflector/telemetry/TelemetryForwarder.java
@@ -105,7 +105,9 @@ public class TelemetryForwarder implements Closeable {
     msg.setProperty("DigitalTwins-Telemetry", "yes");
 
     final EventCallback callback = new EventCallback();
-    client.sendEventAsync(msg, callback, msg);
+    if (client != null) {
+      client.sendEventAsync(msg, callback, msg);
+    }
   }
 
   @Override


### PR DESCRIPTION
Hello, @microsoft!

Method innovation `sendEventAsync` in `../telemetry/TelemetryForwarder.java` may produce `NullPointerException`, so I add null check for sendEventAsync method result.

Please merge my change if you think these changes are correct.
Please do not mark this as spam.